### PR TITLE
added nlp pre-trained model for sentiment analysis, suitable to catch  help requests

### DIFF
--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -2168,6 +2168,7 @@ class Mod(commands.Cog):
                     "You'll get more focused help there! 👋"
                 )
                 await message.reply(response)
+            continue
         
         guild_id = message.guild.id
         config = await self.get_guild_config(guild_id)


### PR DESCRIPTION
This adds NLP to the mod.py file, which is later used in the `on_message` existing event to catch any possible help request made in the #general chat into the discord.py server and reply to the user with a simple message to point them the right help channel.

This is a very basic implementation and can be totally fine-tuned to preferences, as well as fine-tuning the NLP model to ensure it catches exactly only help requests, by using some common help messages datasets.

I did test this implementation before creating this PR, so further analysis is needed if merging is approved.
